### PR TITLE
Add basic portfolio site with project pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,10 +3,35 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>My Site</title>
+    <title>Matt McGinley Portfolio</title>
+    <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <h1>This is my Github Pages Website!</h1>
-    
+    <header>
+        <h1>Matt McGinley</h1>
+        <p>Welcome to my web development portfolio. Explore some of my projects below.</p>
+    </header>
+    <main>
+        <section class="projects">
+            <h2>Projects</h2>
+            <div class="project-list">
+                <a class="project" href="projects/mock-draft-simulator/">
+                    <h3>Mock Draft Simulator</h3>
+                    <p>An interactive tool for practicing draft strategies.</p>
+                </a>
+                <a class="project" href="projects/bitcoin-site/">
+                    <h3>Bitcoin Site</h3>
+                    <p>A site exploring Bitcoin trends and data.</p>
+                </a>
+                <a class="project" href="projects/personal-training-site/">
+                    <h3>Personal Training Site</h3>
+                    <p>Showcasing fitness programs and training info.</p>
+                </a>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 Matt McGinley</p>
+    </footer>
 </body>
 </html>

--- a/projects/bitcoin-site/index.html
+++ b/projects/bitcoin-site/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Bitcoin Site</title>
+    <link rel="stylesheet" href="../../styles.css">
+</head>
+<body>
+    <header>
+        <h1>Bitcoin Site</h1>
+    </header>
+    <main>
+        <p>This project explores Bitcoin trends, prices, and educational resources. More information will be added here soon.</p>
+        <p><a href="../../index.html">Back to portfolio</a></p>
+    </main>
+    <footer>
+        <p>&copy; 2024 Matt McGinley</p>
+    </footer>
+</body>
+</html>

--- a/projects/mock-draft-simulator/index.html
+++ b/projects/mock-draft-simulator/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Mock Draft Simulator</title>
+    <link rel="stylesheet" href="../../styles.css">
+</head>
+<body>
+    <header>
+        <h1>Mock Draft Simulator</h1>
+    </header>
+    <main>
+        <p>This project will let you practice draft strategies through a simulated draft environment. More details coming soon!</p>
+        <p><a href="../../index.html">Back to portfolio</a></p>
+    </main>
+    <footer>
+        <p>&copy; 2024 Matt McGinley</p>
+    </footer>
+</body>
+</html>

--- a/projects/personal-training-site/index.html
+++ b/projects/personal-training-site/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Personal Training Site</title>
+    <link rel="stylesheet" href="../../styles.css">
+</head>
+<body>
+    <header>
+        <h1>Personal Training Site</h1>
+    </header>
+    <main>
+        <p>Here you'll find information about training programs, schedules, and tips. Content will be added as the project grows.</p>
+        <p><a href="../../index.html">Back to portfolio</a></p>
+    </main>
+    <footer>
+        <p>&copy; 2024 Matt McGinley</p>
+    </footer>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,55 @@
+body {
+    font-family: Arial, sans-serif;
+    margin: 0;
+    padding: 0;
+    background-color: #f9f9f9;
+    color: #333;
+}
+
+header {
+    background-color: #4a90e2;
+    color: white;
+    padding: 2rem 1rem;
+    text-align: center;
+}
+
+h1 {
+    margin: 0 0 0.5rem 0;
+}
+
+main {
+    padding: 2rem 1rem;
+}
+
+.projects h2 {
+    text-align: center;
+    margin-bottom: 1rem;
+}
+
+.project-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    justify-content: center;
+}
+
+.project {
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 1rem;
+    width: 260px;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.2s;
+}
+
+.project:hover {
+    transform: translateY(-4px);
+}
+
+footer {
+    text-align: center;
+    padding: 1rem;
+    background-color: #eee;
+}


### PR DESCRIPTION
## Summary
- set up index page with simple project links
- style portfolio with a new CSS file
- add placeholder pages for mock draft simulator, bitcoin site, and personal training site

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882bcbb4a44832693a6d544b2ad131e