### PR TITLE
Enhance portfolio page with intro, about and skills

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,37 @@
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
-    <header>
+    <header class="hero">
         <h1>Matt McGinley</h1>
-        <p>Welcome to my web development portfolio. Explore some of my projects below.</p>
+        <p class="tagline">Front-end developer crafting modern web experiences that engage and inspire.</p>
+        <a class="cta" href="resume.pdf">View Resume</a>
     </header>
     <main>
+        <section class="about">
+            <h2>About Me</h2>
+            <div class="about-content">
+                <img src="images/headshot.png" alt="Matt McGinley headshot">
+                <div class="bio">
+                    <p>I'm a passionate developer who loves turning ideas into interactive experiences on the web. After years of tinkering with code, I've honed my skills in building responsive sites that put usability first.</p>
+                    <p>My background in sports and fitness drives my focus on performance, whether it's page load times or hitting personal goals at the gym. When I'm not coding, you'll find me gaming or staying active.</p>
+                    <p>I'm always eager to collaborate on new projects and push my skills further.</p>
+                    <ul class="quick-facts">
+                        <li><strong>Location:</strong> Pennsylvania</li>
+                        <li><strong>Specialties:</strong> HTML, CSS, JavaScript</li>
+                        <li><strong>Passions:</strong> sports, fitness, gaming</li>
+                    </ul>
+                </div>
+            </div>
+        </section>
+        <section class="skills">
+            <h2>Skills &amp; Tech Stack</h2>
+            <div class="skill"><span>HTML</span><div class="bar"><div class="level" style="width: 90%"></div></div></div>
+            <div class="skill"><span>CSS</span><div class="bar"><div class="level" style="width: 90%"></div></div></div>
+            <div class="skill"><span>JavaScript</span><div class="bar"><div class="level" style="width: 80%"></div></div></div>
+            <div class="skill"><span>React</span><div class="bar"><div class="level" style="width: 75%"></div></div></div>
+            <div class="skill"><span>Git</span><div class="bar"><div class="level" style="width: 85%"></div></div></div>
+            <div class="skill"><span>Communication</span><div class="bar"><div class="level" style="width: 90%"></div></div></div>
+        </section>
         <section class="projects">
             <h2>Projects</h2>
             <div class="project-list">

--- a/styles.css
+++ b/styles.css
@@ -6,11 +6,26 @@ body {
     color: #333;
 }
 
-header {
+header.hero {
     background-color: #4a90e2;
     color: white;
-    padding: 2rem 1rem;
+    padding: 3rem 1rem;
     text-align: center;
+}
+
+.cta {
+    display: inline-block;
+    margin-top: 1rem;
+    padding: 0.5rem 1.25rem;
+    background: #fff;
+    color: #4a90e2;
+    border-radius: 4px;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.tagline {
+    margin: 0.5rem 0 0.75rem 0;
 }
 
 h1 {
@@ -52,4 +67,61 @@ footer {
     text-align: center;
     padding: 1rem;
     background-color: #eee;
+}
+
+.about-content {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    max-width: 800px;
+    margin: 0 auto 2rem auto;
+}
+
+.about-content img {
+    width: 180px;
+    border-radius: 50%;
+}
+
+.bio p {
+    margin-top: 0;
+    margin-bottom: 0.75rem;
+}
+
+.quick-facts {
+    list-style: none;
+    padding: 0;
+}
+
+.quick-facts li {
+    margin-bottom: 0.25rem;
+}
+
+.skills {
+    max-width: 600px;
+    margin: 0 auto 2rem auto;
+}
+
+.skill {
+    margin-bottom: 0.5rem;
+}
+
+.skill span {
+    display: inline-block;
+    width: 130px;
+}
+
+.bar {
+    display: inline-block;
+    vertical-align: middle;
+    width: 60%;
+    height: 8px;
+    background: #ddd;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.level {
+    height: 100%;
+    background: #4a90e2;
 }


### PR DESCRIPTION
## Summary
- add hero section with tagline and call to action
- introduce an About Me block with bio, quick facts and placeholder headshot
- list skills using progress bars
- include empty `images` folder for assets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6882c27b47d48326b0cd927a1cc63ccb