### PR TITLE
Improve portfolio styling and simplify skills section

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,12 +31,11 @@
         </section>
         <section class="skills">
             <h2>Skills &amp; Tech Stack</h2>
-            <div class="skill"><span>HTML</span><div class="bar"><div class="level" style="width: 90%"></div></div></div>
-            <div class="skill"><span>CSS</span><div class="bar"><div class="level" style="width: 90%"></div></div></div>
-            <div class="skill"><span>JavaScript</span><div class="bar"><div class="level" style="width: 80%"></div></div></div>
-            <div class="skill"><span>React</span><div class="bar"><div class="level" style="width: 75%"></div></div></div>
-            <div class="skill"><span>Git</span><div class="bar"><div class="level" style="width: 85%"></div></div></div>
-            <div class="skill"><span>Communication</span><div class="bar"><div class="level" style="width: 90%"></div></div></div>
+            <ul class="skills-list">
+                <li>HTML</li>
+                <li>CSS</li>
+                <li>Full Stack JavaScript</li>
+            </ul>
         </section>
         <section class="projects">
             <h2>Projects</h2>

--- a/styles.css
+++ b/styles.css
@@ -1,16 +1,20 @@
+@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap');
+
 body {
-    font-family: Arial, sans-serif;
+    font-family: 'Poppins', Arial, sans-serif;
     margin: 0;
     padding: 0;
-    background-color: #f9f9f9;
+    background-color: #f5f7fa;
     color: #333;
+    line-height: 1.6;
 }
 
 header.hero {
-    background-color: #4a90e2;
+    background: linear-gradient(135deg, #4a90e2, #76b1ff);
     color: white;
     padding: 3rem 1rem;
     text-align: center;
+    box-shadow: 0 2px 6px rgba(0,0,0,0.1);
 }
 
 .cta {
@@ -34,6 +38,8 @@ h1 {
 
 main {
     padding: 2rem 1rem;
+    max-width: 900px;
+    margin: 0 auto;
 }
 
 .projects h2 {
@@ -100,28 +106,21 @@ footer {
 .skills {
     max-width: 600px;
     margin: 0 auto 2rem auto;
+    text-align: center;
 }
 
-.skill {
-    margin-bottom: 0.5rem;
+.skills-list {
+    list-style: none;
+    padding: 0;
+    display: flex;
+    gap: 1rem;
+    justify-content: center;
 }
 
-.skill span {
-    display: inline-block;
-    width: 130px;
-}
-
-.bar {
-    display: inline-block;
-    vertical-align: middle;
-    width: 60%;
-    height: 8px;
-    background: #ddd;
+.skills-list li {
+    background: #fff;
     border-radius: 4px;
-    overflow: hidden;
-}
-
-.level {
-    height: 100%;
-    background: #4a90e2;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 0.5rem 1rem;
+    font-weight: 600;
 }


### PR DESCRIPTION
## Summary
- remove progress bars from skills section
- update skills to HTML, CSS and Full Stack JavaScript
- import Poppins font and tweak colors
- center main content and add modern hero styling

## Testing
- `git diff --cached --stat`


------
https://chatgpt.com/codex/tasks/task_e_688946ec6c488326af2a138329099ad9