### PR TITLE
Improve headshot sizing and page layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
         <section class="about">
             <h2>About Me</h2>
             <div class="about-content">
-                <img src="images/MattProfilePicture.png" alt="Matt McGinley headshot">
+                <img src="images/MattProfilePicture.png" alt="Headshot of Matt McGinley">
                 <div class="bio">
                     <p>I love working out, playing video games and learning about tech. Trying to understand Bitcoin from a computer science perspective brought me down a rabbit hole of learning software engineering. Once I learned some skills, I decided that I wanted to build my own personal training website and Bitcoin page, so here I am!</p>
                     <p>My background in sports and fitness drives my focus on performance, whether it's page load times or hitting personal goals at the gym.</p>

--- a/styles.css
+++ b/styles.css
@@ -34,6 +34,7 @@ header.hero {
 
 h1 {
     margin: 0 0 0.5rem 0;
+    font-size: 2.25rem;
 }
 
 main {
@@ -45,6 +46,10 @@ main {
 .projects h2 {
     text-align: center;
     margin-bottom: 1rem;
+}
+
+.projects {
+    padding: 2rem 1rem;
 }
 
 .project-list {
@@ -75,6 +80,14 @@ footer {
     background-color: #eee;
 }
 
+.about {
+    background-color: #fff;
+    border-radius: 8px;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    padding: 2rem 1rem;
+    margin-bottom: 2rem;
+}
+
 .about-content {
     display: flex;
     flex-wrap: wrap;
@@ -85,7 +98,7 @@ footer {
 }
 
 .about-content img {
-    width: 180px;
+    width: 220px;
     border-radius: 50%;
 }
 
@@ -107,6 +120,7 @@ footer {
     max-width: 600px;
     margin: 0 auto 2rem auto;
     text-align: center;
+    padding: 2rem 1rem;
 }
 
 .skills-list {


### PR DESCRIPTION
## Summary
- enlarge profile headshot so it doesn't crop the top
- tweak page layout styles for a cleaner look
- update alt text on profile picture

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68895cef660c8326be73950122a0e64d