### PR TITLE
Improve About section layout and gradient

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,15 +17,13 @@
         <section class="about">
             <h2>About Me</h2>
             <div class="about-content">
-                <img src="images/MattProfilePicture.png" alt="Headshot of Matt McGinley">
+                <img src="images/MattProfilePicture.png" alt="Headshot of Matt McGinley smiling">
                 <div class="bio">
-                    <p>I love working out, playing video games and learning about tech. Trying to understand Bitcoin from a computer science perspective brought me down a rabbit hole of learning software engineering. Once I learned some skills, I decided that I wanted to build my own personal training website and Bitcoin page, so here I am!</p>
-                    <p>My background in sports and fitness drives my focus on performance, whether it's page load times or hitting personal goals at the gym.</p>
-                    <p>I'm always eager to collaborate on new projects and push my skills further.</p>
+                    <p>I'm a Pennsylvania-based developer who loves staying active, exploring video games and diving into tech. Curiosity about Bitcoin drew me into programming, and I quickly discovered a passion for building sleek, high-performance websites. My sports background pushes me to chase new goals in both fitness and code, motivating me to deliver fast, user-friendly experiences. I'm excited to collaborate on projects that challenge me and help me grow as a developer.</p>
                     <ul class="quick-facts">
-                        <li><strong>Location:</strong> Pennsylvania</li>
-                        <li><strong>Specialties:</strong> HTML, CSS, JavaScript</li>
-                        <li><strong>Passions:</strong> sports, fitness, gaming</li>
+                        <li>🗺️ <span>Location:</span> Pennsylvania</li>
+                        <li>💻 <span>Stack:</span> HTML, CSS, JavaScript</li>
+                        <li>🏋️ <span>Passions:</span> sports, fitness, gaming</li>
                     </ul>
                 </div>
             </div>

--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,7 @@ body {
 }
 
 header.hero {
-    background: linear-gradient(135deg, #4a90e2, #76b1ff);
+    background: linear-gradient(135deg, #4f8dfd 0%, #7fb8ff 100%);
     color: white;
     padding: 3rem 1rem;
     text-align: center;
@@ -99,9 +99,9 @@ footer {
 }
 
 .about-content {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 1rem;
+    display: grid;
+    grid-template-columns: 220px 1fr;
+    gap: 2rem;
     align-items: center;
     max-width: 800px;
     margin: 0 auto 2rem auto;
@@ -109,14 +109,28 @@ footer {
 
 .about-content img {
     width: 220px;
-    /* Display original rectangular shape */
     border-radius: 0;
+    transition: transform 0.2s, box-shadow 0.2s;
 }
 
+.about-content img:hover {
+    transform: translateY(-4px);
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+}
+@media (max-width: 600px) {
+    .about-content {
+        grid-template-columns: 1fr;
+        text-align: center;
+    }
+    .about-content img {
+        margin: 0 auto;
+    }
+}
 .bio p {
     margin-top: 0;
     margin-bottom: 0.75rem;
 }
+
 
 .quick-facts {
     list-style: none;
@@ -124,7 +138,13 @@ footer {
 }
 
 .quick-facts li {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
     margin-bottom: 0.25rem;
+}
+.quick-facts span {
+    font-weight: 600;
 }
 
 .skills {


### PR DESCRIPTION
## Summary
- lighten hero gradient colors
- restructure About Me section into a responsive grid
- condense bio text to ~80 words
- present quick facts with icons
- add hover effect and alt text

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_688aa0affde08326be5e6fdc251f4224